### PR TITLE
Fix typo in sample-device.md: `デー` to `データ`

### DIFF
--- a/books/siv3d-documentation/sample-device.md
+++ b/books/siv3d-documentation/sample-device.md
@@ -36,7 +36,7 @@ void loop()
     // シリアル通信で受信したデータを読み込む
     const int val = Serial.read();
 
-    if (val == -1) // 受信したデーが無い
+    if (val == -1) // 受信したデータが無い
     {
         return;
     }


### PR DESCRIPTION
[sample-device.md](https://github.com/Reputeless/Zenn.Public/blob/main/books/siv3d-documentation/sample-device.md) における誤字を修正しました。

- 加えられた変更のあるページ
[Chapter 56 サンプル集 | 外部デバイスとの連携](https://zenn.dev/reputeless/books/siv3d-documentation/viewer/sample-device)